### PR TITLE
use svyset design in etotal

### DIFF
--- a/src/etotal.ado
+++ b/src/etotal.ado
@@ -32,7 +32,9 @@ Total of expression
 {synopthdr}
 {synoptline}
     {synopt:{opth over(varname)}}group over subpopulations defined by {it:varname}.{p_end}
+	{synopt:{opt svy}}adjust the results for survey settings identified by {bf:{help svyset}}.{p_end}
     {synopt:{opt level(#)}}set confidence level; default is {bf:level(95)}.{p_end}
+	{synopt:{opth cformat(%fmt)}}:specifies how to format estimates, standard errors, and confidence limits; deftault is {bf:cformat(%14.0fc)}.{p_end}
 	{synopt:{opt mat:rix(string)}}save results in matrix named _string_.{p_end}
 {synoptline}
 
@@ -47,9 +49,13 @@ Example(s)
 
     Total of existing variable  
         {bf:. etotal hincp [iw=wgtp]}
+	
+	Total of existing variable, data is svyset  
+        {bf:. etotal hincp, svy}
 
     Total of expression, saving results in matrix  
         {bf:. etotal hincp / 1000 [iw=wgtp], matrix(tot_hh_inc_thous)}
+
 
 Website
 -------
@@ -66,10 +72,25 @@ capture program drop etotal
 
 program define etotal
 
-	syntax [anything] [if] [fweight pweight iweight], 	                   ///
-		   [level(cilevel)] [over(varname numeric)] [MATrix(name)]
+	syntax [anything] [if] [fweight pweight iweight], 	                ///
+		   [svy] [level(cilevel)] [over(varname numeric)] 				///
+		   [MATrix(name)] [cformat(string)]
+		   
+		   
     
-    
+	if "`svy'" != "" {
+	    local is_svyset = `"`r(settings)'"' != ", clear"
+		if !`is_svyset' {
+		    display as error "data not set up for svy, use {help svyset}"
+			exit 119
+		}
+		if "`weight'" != "" {
+		    display as error "weights not allowed with {bf:svy}"
+			exit 184
+		}
+		local svy "svy:"
+	}
+
 	* if over is specified, get value labels for results matrix ---------------
 	
 	if "`over'" != "" {
@@ -105,7 +126,7 @@ program define etotal
 		local rxm_if = ustrregexm("`anything'", "`rx_logic'|`rx_rel'")
 		
 		if `rxm_if' == 1 {
-			display as yellow "Next time, put logical or relational expressions in [{bf:if}]."
+			display as result "next time, put logical or relational expressions in [{bf:if}]."
 		}
 		
 		if `rxm_arithm' == 1 | `rxm_if' == 1 {
@@ -122,7 +143,7 @@ program define etotal
 		
 		* 1.3. create results for totals --------------------------------------
 		
-	    quietly total `tally_var' `if' [`weight' `exp'], level(`level')
+	    quietly `svy' total `tally_var' `if' [`weight' `exp'], level(`level')
 		matrix `tally_all' = r(table)'
 		
 		if "`over'" == "" {
@@ -130,7 +151,7 @@ program define etotal
 		}
 		
 		if "`over'" != "" {
-		    quietly total `tally_var' `if' [`weight' `exp'],    ///
+		    quietly `svy' total `tally_var' `if' [`weight' `exp'],    ///
                           over(`over') level(`level')
 			matrix `tally_by' = r(table)'
 			matrix `results' = `tally_by' \ `tally_all'
@@ -144,7 +165,7 @@ program define etotal
 	    
 		* 2.1. an unweighted count -> use count -------------------------------
 		
-		if "`weight'" == ""  {
+		if ("`weight'" == "") & ("`svy'" == "")  {
 			
 			if "`over'" == "" {
 			    quietly count `if'
@@ -159,11 +180,11 @@ program define etotal
 		
 		// 2.2. a weighted count -> tally_var is 1 ----------------------------
 		
-		if "`weight'" != "" {
+		if ("`weight'" != "") | ("`svy'" != "") {
 		    
 			tempvar tally_var
 			quietly generate `tally_var' = 1
-			quietly total `tally_var' `if' [`weight' `exp'], level(`level')
+			quietly `svy' total `tally_var' `if' [`weight' `exp'], level(`level')
 			matrix `tally_all' = r(table)'
 			
 			if "`over'" == "" {
@@ -171,7 +192,7 @@ program define etotal
 			}
 			
 			if "`over'" != "" {
-			    quietly total i.`over' `if' [`weight' `exp'], level(`level')
+			    quietly `svy' total i.`over' `if' [`weight' `exp'], level(`level')
 				matrix `tally_by' = r(table)'
 				matrix `results' = `tally_by' \ `tally_all'
 			}
@@ -181,24 +202,26 @@ program define etotal
     
 	* format results ----------------------------------------------------------
 	
-	if "`weight'" == "" {
+	local cformat = cond("`cformat'" == "", "%14.0fc", "`cformat'")
+	
+	if ("`weight'" == "") & ("`svy'" == "") {
 	    matrix `results' = `results'[1..., 1]
 		local first_colname = cond("`anything'" == "", "Count:", "Total:")
 		matrix colnames `results' = "`first_colname'" 
-		local cspec "& %14s | %15.0fc &"
+		local cspec "& %14s | `cformat' &"
 	}
 	
-	if "`weight'" != "" {
+	if ("`weight'" != "") | ("`svy'" != "") {
 		local first_colname = cond("`anything'" == "", 			        ///
 								   "Weighted Count:", 			        ///
 								   "Total:")
 		matrix `results' = `results'[1..., 1..2] , 				        ///
 						   `results'[1..., 5..6]
 		matrix colnames `results' = "`first_colname'" 			        ///
-									"Std. Err.:" 				        ///
+									"Std. Err.:" 				   		///
 									"[`level'% Conf. Interval]:lb"  	///
 									"[`level'% Conf. Interval]:ub" 
-		local cspec "& %14s | %15.0fc | %13.0fc | %13.0fc & %13.0fc &"
+		local cspec "& %14s | `cformat' | `cformat' | `cformat' & `cformat' &"
 	}
 	
 	if "`over'" == "" {
@@ -227,6 +250,10 @@ program define etotal
 	matlist `results', showcoleq(combined) coleqonly  		///
 					   rspec("`rspec'") cspec("`cspec'")
 	display ""
+	if "`e(vcetype)'" != "" {
+	    display as text "note: `e(vcetype)' variance estimation"
+		display ""
+	}
 		
 	if "`matrix'" != "" {
 	    matrix `matrix' = `results'

--- a/src/etotal.ado
+++ b/src/etotal.ado
@@ -50,7 +50,7 @@ Example(s)
     Total of existing variable  
         {bf:. etotal hincp [iw=wgtp]}
 	
-	Total of existing variable, data is svyset  
+    Total of existing variable, data is svyset  
         {bf:. etotal hincp, svy}
 
     Total of expression, saving results in matrix  
@@ -100,6 +100,8 @@ program define etotal
 			local over_lbls ""
 			foreach l of local over_lvls {
 				local lbl : label `over_lbl_nm' `l'
+                local lbl = ustrregexra("`lbl'", "\.", "")
+                local lbl = usubstr("`lbl'", 1, 32)
 				local over_lbls = `"`over_lbls'"' + " " + `"""' + "`lbl'" + `"""'
 			}
 			local over_lbls = `"`over_lbls'"' + `""Overall""'
@@ -239,7 +241,7 @@ program define etotal
 	if "`over'" != "" {
 	    local rand = "&" * (rowsof(`results') - 2)
 		local rspec "&|`rand'|&"
-		if "`over_lbls'" != "" {
+		if `"`over_lbls'"' != "" {
 			matrix rownames `results' = `over_lbls'
 		}
 	}

--- a/src/etotal.sthlp
+++ b/src/etotal.sthlp
@@ -36,7 +36,9 @@ Total of expression
 {synopthdr}
 {synoptline}
     {synopt:{opth over(varname)}}group over subpopulations defined by {it:varname}.{p_end}
+	{synopt:{opt svy}}adjust the results for survey settings identified by {bf:{help svyset}}.{p_end}
     {synopt:{opt level(#)}}set confidence level; default is {bf:level(95)}.{p_end}
+	{synopt:{opth cformat(%fmt)}}:specifies how to format estimates, standard errors, and confidence limits; deftault is {bf:cformat(%14.0fc)}.{p_end}
 	{synopt:{opt mat:rix(string)}}save results in matrix named {it:string}.{p_end}
 {synoptline}
 
@@ -52,9 +54,14 @@ Total of expression
 
     Total of existing variable  
         {bf:. etotal hincp [iw=wgtp]}
+	
+	Total of existing variable, data is svyset
+        {bf:. etotal hincp, svy}
 
     Total of expression, saving results in matrix  
         {bf:. etotal hincp / 1000 [iw=wgtp], matrix(tot_hh_inc_thous)}
+
+
 
 
 {title:Website}

--- a/src/etotal.sthlp
+++ b/src/etotal.sthlp
@@ -55,12 +55,11 @@ Total of expression
     Total of existing variable  
         {bf:. etotal hincp [iw=wgtp]}
 	
-	Total of existing variable, data is svyset
+    Total of existing variable, data is svyset  
         {bf:. etotal hincp, svy}
 
     Total of expression, saving results in matrix  
         {bf:. etotal hincp / 1000 [iw=wgtp], matrix(tot_hh_inc_thous)}
-
 
 
 


### PR DESCRIPTION
Add `svy` option to have `etotal` use `svy:` prefix under the hood. 

(Can't make `etotal` itself support the `svy:` prefix without a good deal of work; see pg. 3 [here](https://www.stata.com/manuals13/pprogramproperties.pdf).)